### PR TITLE
improve import-order to be unambiguous by defining all groups

### DIFF
--- a/ts.js
+++ b/ts.js
@@ -1,7 +1,6 @@
 module.exports = {
   extends: [
     'eslint:recommended',
-    'plugin:@typescript-eslint/strict-type-checked',
     'plugin:import/recommended',
     'plugin:import/typescript',
     'plugin:prettier/recommended'
@@ -27,7 +26,8 @@ module.exports = {
   overrides: [
     {
       extends: [
-        'plugin:@typescript-eslint/recommended-requiring-type-checking'
+        'plugin:@typescript-eslint/strict-type-checked',
+        'plugin:@typescript-eslint/stylistic-type-checked',
       ],
       files: ['./**/*.{ts,tsx}']
     }
@@ -47,8 +47,25 @@ module.exports = {
     'import/order': [
       'error',
       {
-        groups: ['builtin', 'external', 'unknown', 'parent', 'sibling', 'index']
-      }
+        groups: [
+          'builtin',
+          'external',
+          'internal',
+          'unknown',
+          'parent',
+          'sibling',
+          'index',
+          'object',
+          'type',
+        ],
+        alphabetize: {
+          order: 'asc',
+          orderImportKind: 'asc',
+          caseInsensitive: true,
+        },
+        'newlines-between': 'never',
+        warnOnUnassignedImports: true,
+      },
     ],
     'no-console': [
       'error',

--- a/ts.js
+++ b/ts.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: [
     'eslint:recommended',
+    'plugin:@typescript-eslint/strict-type-checked',
     'plugin:import/recommended',
     'plugin:import/typescript',
     'plugin:prettier/recommended'
@@ -26,8 +27,7 @@ module.exports = {
   overrides: [
     {
       extends: [
-        'plugin:@typescript-eslint/strict-type-checked',
-        'plugin:@typescript-eslint/stylistic-type-checked',
+        'plugin:@typescript-eslint/recommended-requiring-type-checking'
       ],
       files: ['./**/*.{ts,tsx}']
     }


### PR DESCRIPTION
These changes will break the current order, but it's automatically fixable.