### PR TITLE
use strict-type-checked and stylistic-type-checked for typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aboutbits/eslint-config",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aboutbits/eslint-config",
-      "version": "3.0.0-beta.1",
+      "version": "3.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/parser": "^6.1.0 || ^7.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aboutbits/eslint-config",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aboutbits/eslint-config",
-      "version": "3.0.0-beta.2",
+      "version": "3.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/parser": "^6.1.0 || ^7.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aboutbits/eslint-config",
-  "version": "2.4.0",
+  "version": "3.0.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aboutbits/eslint-config",
-      "version": "2.4.0",
+      "version": "3.0.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/parser": "^6.1.0 || ^7.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aboutbits/eslint-config",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aboutbits/eslint-config",
-      "version": "3.0.0-beta.0",
+      "version": "3.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/parser": "^6.1.0 || ^7.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aboutbits/eslint-config",
-  "version": "2.4.0",
+  "version": "3.0.0-beta.0",
   "description": "AboutBits' ESLint config presets",
   "author": "AboutBits",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aboutbits/eslint-config",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "AboutBits' ESLint config presets",
   "author": "AboutBits",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aboutbits/eslint-config",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "description": "AboutBits' ESLint config presets",
   "author": "AboutBits",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aboutbits/eslint-config",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "description": "AboutBits' ESLint config presets",
   "author": "AboutBits",
   "license": "MIT",

--- a/ts.js
+++ b/ts.js
@@ -1,7 +1,6 @@
 module.exports = {
   extends: [
     'eslint:recommended',
-    'plugin:@typescript-eslint/strict-type-checked',
     'plugin:import/recommended',
     'plugin:import/typescript',
     'plugin:prettier/recommended'
@@ -27,7 +26,8 @@ module.exports = {
   overrides: [
     {
       extends: [
-        'plugin:@typescript-eslint/recommended-requiring-type-checking'
+        'plugin:@typescript-eslint/strict-type-checked',
+        'plugin:@typescript-eslint/stylistic-type-checked',
       ],
       files: ['./**/*.{ts,tsx}']
     }

--- a/ts.js
+++ b/ts.js
@@ -1,6 +1,8 @@
 module.exports = {
   extends: [
     'eslint:recommended',
+    'plugin:@typescript-eslint/strict-type-checked',
+    'plugin:@typescript-eslint/stylistic-type-checked',
     'plugin:import/recommended',
     'plugin:import/typescript',
     'plugin:prettier/recommended'
@@ -24,13 +26,6 @@ module.exports = {
     }
   },
   overrides: [
-    {
-      extends: [
-        'plugin:@typescript-eslint/strict-type-checked',
-        'plugin:@typescript-eslint/stylistic-type-checked',
-      ],
-      files: ['./**/*.{ts,tsx}']
-    },
     {
       extends: ['plugin:prettier/recommended'],
       files: ['./**/*.json'],

--- a/ts.js
+++ b/ts.js
@@ -58,6 +58,10 @@ module.exports = {
         'allowNever': false,
       }
     ],
+    '@typescript-eslint/consistent-type-definitions': [
+      'error',
+      'type'
+    ],
     'import/order': [
       'error',
       {


### PR DESCRIPTION
>[!CAUTION]
>This will certainly introduce rule violations that need to be fixed manually in the project.

We are using it in a client's project and I would recommend to enable these rules, but of course open for discussion.

I would release a new major version for these rules.