### PR TITLE
force import member sort

### DIFF
--- a/ts.js
+++ b/ts.js
@@ -81,6 +81,12 @@ module.exports = {
         warnOnUnassignedImports: true,
       },
     ],
+    'sort-imports': [
+      'error',
+      {
+        ignoreDeclarationSort: true
+      }
+    ],
     'no-console': [
       'error',
       {

--- a/ts.js
+++ b/ts.js
@@ -84,6 +84,7 @@ module.exports = {
     'sort-imports': [
       'error',
       {
+        // The declarations are sorted more granularly by the import/order plugin.
         ignoreDeclarationSort: true
       }
     ],


### PR DESCRIPTION
This improves our import order to also force the named import declarations to be sorted, and prevents these changes in a PR:

<img width="360" alt="image" src="https://github.com/aboutbits/eslint-config/assets/9607491/4da9eae1-96ed-4a57-9a41-cbb2c0198897">
