### PR TITLE
add eslint-plugin-unused-imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-tailwindcss": "^3.15.1",
+        "eslint-plugin-unused-imports": "^3.2.0",
         "prettier": "^3.2.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -2192,6 +2193,38 @@
       },
       "peerDependencies": {
         "tailwindcss": "^3.4.0"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.2.0.tgz",
+      "integrity": "sha512-6uXyn6xdINEpxE1MtDjxQsyXB37lfyO2yKGVVgtD7WEWQGORSOZjgrD6hBhvGv4/SO+TOlS+UnC6JppRqbuwGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-rule-composer": "^0.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "6 - 7",
+        "eslint": "8"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -6740,6 +6773,21 @@
         "fast-glob": "^3.2.5",
         "postcss": "^8.4.4"
       }
+    },
+    "eslint-plugin-unused-imports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.2.0.tgz",
+      "integrity": "sha512-6uXyn6xdINEpxE1MtDjxQsyXB37lfyO2yKGVVgtD7WEWQGORSOZjgrD6hBhvGv4/SO+TOlS+UnC6JppRqbuwGQ==",
+      "dev": true,
+      "requires": {
+        "eslint-rule-composer": "^0.3.0"
+      }
+    },
+    "eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "7.2.2",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-tailwindcss": "^3.15.1",
+    "eslint-plugin-unused-imports": "^3.2.0",
     "prettier": "^3.2.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -84,6 +85,7 @@
     "eslint-plugin-react": "^7.33.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-tailwindcss": "^3.13.0",
+    "eslint-plugin-unused-imports": "^3.2.0",
     "prettier": "^3.0.0"
   },
   "peerDependenciesMeta": {

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ Then change `.eslintrc.json` to be:
 Install the required packages, assuming that you have TypeScript already installed:
 
 ```sh
-npm i -D eslint prettier @typescript-eslint/eslint-plugin eslint-plugin-prettier eslint-plugin-import
+npm i -D eslint prettier @typescript-eslint/eslint-plugin eslint-plugin-prettier eslint-plugin-import eslint-plugin-unused-imports@^3
 ```
 
 `.eslintrc.json`
@@ -83,7 +83,7 @@ npm i -D eslint prettier @typescript-eslint/eslint-plugin eslint-plugin-prettier
 Install the required packages, assuming that you have TypeScript already installed:
 
 ```sh
-npm i -D eslint prettier @typescript-eslint/eslint-plugin eslint-plugin-prettier eslint-plugin-import eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-jsx-a11y eslint-plugin-tailwindcss
+npm i -D eslint prettier @typescript-eslint/eslint-plugin eslint-plugin-prettier eslint-plugin-import eslint-plugin-unused-imports@^3 eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-jsx-a11y eslint-plugin-tailwindcss
 ```
 
 `.eslintrc.json`
@@ -102,7 +102,7 @@ npm i -D eslint prettier @typescript-eslint/eslint-plugin eslint-plugin-prettier
 Install the required packages, assuming that you have TypeScript already installed:
 
 ```sh
-npm i -D eslint prettier @typescript-eslint/eslint-plugin eslint-plugin-prettier eslint-plugin-import eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-jsx-a11y eslint-plugin-tailwindcss @next/eslint-plugin-next
+npm i -D eslint prettier @typescript-eslint/eslint-plugin eslint-plugin-prettier eslint-plugin-import eslint-plugin-unused-imports@^3 eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-jsx-a11y eslint-plugin-tailwindcss @next/eslint-plugin-next
 ```
 
 `.eslintrc.json`
@@ -144,7 +144,7 @@ The following shows how to combine it with the preset `ts-next`:
 Install the required packages, assuming that you have TypeScript already installed:
 
 ```sh
-npm i -D eslint prettier @typescript-eslint/eslint-plugin eslint-plugin-prettier eslint-plugin-import eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-jsx-a11y eslint-plugin-tailwindcss @next/eslint-plugin-next eslint-plugin-formatjs
+npm i -D eslint prettier @typescript-eslint/eslint-plugin eslint-plugin-prettier eslint-plugin-import eslint-plugin-unused-imports@^3 eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-jsx-a11y eslint-plugin-tailwindcss @next/eslint-plugin-next eslint-plugin-formatjs
 ```
 
 `.eslintrc.json`

--- a/ts.js
+++ b/ts.js
@@ -12,7 +12,7 @@ module.exports = {
     sourceType: 'module',
     ecmaVersion: 2020
   },
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', 'eslint-plugin-unused-imports'],
   env: {
     node: true,
     browser: true,
@@ -36,15 +36,6 @@ module.exports = {
     },
   ],
   rules: {
-    '@typescript-eslint/no-unused-vars': [
-      'error',
-      {
-        ignoreRestSiblings: true,
-        varsIgnorePattern: '^[iI]gnored',
-        argsIgnorePattern: '^_',
-        caughtErrorsIgnorePattern: '^ignore'
-      }
-    ],
     '@typescript-eslint/member-delimiter-style': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/restrict-template-expressions': [
@@ -96,6 +87,19 @@ module.exports = {
     curly: ['error', 'all'],
     'object-shorthand': ['error'],
     eqeqeq: 'error',
-    'arrow-body-style': 'error'
-  }
+    'arrow-body-style': 'error',
+
+    // Rules for eslint-plugin-unused-imports
+    '@typescript-eslint/no-unused-vars': 'off',
+    'unused-imports/no-unused-imports': 'error',
+    'unused-imports/no-unused-vars': [
+      'error',
+      {
+        ignoreRestSiblings: true,
+        varsIgnorePattern: '^[iI]gnored',
+        argsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^ignore',
+      },
+    ],
+  },
 }


### PR DESCRIPTION
This plugin detects and removes unused imports so that we are not solely reliant on IDE settings.

See https://github.com/sweepline/eslint-plugin-unused-imports