### PR TITLE
do not prefer ?? over || with boolean/nullish union

### DIFF
--- a/configs/ts.js
+++ b/configs/ts.js
@@ -51,6 +51,12 @@ export default defineConfig([
           allowNever: false,
         },
       ],
+      '@typescript-eslint/prefer-nullish-coalescing': [
+        'error',
+        {
+          ignorePrimitives: { boolean: true },
+        },
+      ],
       '@typescript-eslint/member-delimiter-style': 'off',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-deprecated': 'warn',


### PR DESCRIPTION
## Configure `ignorePrimitives` for `prefer-nullish-coalescing`

The `@typescript-eslint/prefer-nullish-coalescing` rule is already enabled via `strictTypeChecked`.

This change adds `ignorePrimitives: { boolean: true }` to allow `||` for boolean union types (`boolean | undefined`, `boolean | null`), where `||` is often the intended operator.

For example, with optional React props typed as `boolean | undefined`:

```tsx
// ✅ Allowed now — || intentionally treats both false and undefined as falsy
disabled={submitting || disabled}
```

Using `??` here would change the semantics: `submitting ?? disabled` returns `false` when `submitting` is `false`, while `||` falls through to `disabled`. For boolean flags, treating `false` and `undefined` the same way is typically what you want.

The rule still enforces `??` for non-boolean nullable types, where falsy coercion is usually a bug:

```ts
// ❌ Still an error — "" and 0 would incorrectly fall through with ||
const name = user.name || "Anonymous";
const count = response.count || 0;

// ✅ Correct
const name = user.name ?? "Anonymous";
const count = response.count ?? 0;
```
See https://typescript-eslint.io/rules/prefer-nullish-coalescing for reference.