### PR TITLE
remove import checks already checked by ts

### DIFF
--- a/configs/ts.js
+++ b/configs/ts.js
@@ -60,6 +60,17 @@ export default defineConfig([
       '@typescript-eslint/member-delimiter-style': 'off',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-deprecated': 'warn',
+      // ----
+      // TypeScript reports all of these rules as part of normal type checking,
+      // and the plugin re-parses the whole import graph to do it.
+      // https://typescript-eslint.io/troubleshooting/typed-linting/performance#eslint-plugin-import
+      // Note: import/no-unresolved stays on, since tsc accepts any path matched by a
+      // wildcard (e.g. Next's '*.module.css') without checking that the file exists.
+      'import/named': 'off',
+      'import/namespace': 'off',
+      'import/default': 'off',
+      'import/no-named-as-default-member': 'off',
+      // ----
       'import/order': [
         'error',
         {


### PR DESCRIPTION
TypeScript reports all of these rules as part of normal type checking, and the plugin re-parses the whole import graph to do it.

See https://typescript-eslint.io/troubleshooting/typed-linting/performance#eslint-plugin-import
 
Note: import/no-unresolved stays on, since tsc accepts any path matched by a wildcard (e.g. Next's '*.module.css') without checking that the file exists.